### PR TITLE
changes for Org in repo name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ Introduction
     :alt: Discord
 
 
-.. image:: https://github.com/circuitpython/CircuitPython_DisplayIO_FlipInput/workflows/Build%20CI/badge.svg
-    :target: https://github.com/circuitpython/CircuitPython_DisplayIO_FlipInput/actions
+.. image:: https://github.com/circuitpython/CircuitPython_Org_DisplayIO_FlipInput/workflows/Build%20CI/badge.svg
+    :target: https://github.com/circuitpython/CircuitPython_Org_DisplayIO_FlipInput/actions
     :alt: Build Status
 
 
@@ -73,7 +73,7 @@ Contributing
 ============
 
 Contributions are welcome! Please read our `Code of Conduct
-<https://github.com/circuitpython/CircuitPython_DisplayIO_FlipInput/blob/HEAD/CODE_OF_CONDUCT.md>`_
+<https://github.com/circuitpython/CircuitPython_Org_DisplayIO_FlipInput/blob/HEAD/CODE_OF_CONDUCT.md>`_
 before contributing to help this project stay welcoming.
 
 Documentation

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/x-rst",
     # The project's main homepage.
-    url="https://github.com/circuitpython/CircuitPython_DisplayIO_FlipInput.git",
+    url="https://github.com/circuitpython/CircuitPython_Org_DisplayIO_FlipInput.git",
     # Author details
     author="Kevin Matocha",
     author_email="",


### PR DESCRIPTION
These changes are needed for the repo name to change to have Org in it.

The repo should get renamed at the same time this is merged.