### PR TITLE
Remove max_size parameter

### DIFF
--- a/displayio_flipinput.py
+++ b/displayio_flipinput.py
@@ -103,7 +103,7 @@ class FlipInput(Widget, Control):
         **kwargs,
     ):
 
-        super().__init__(**kwargs, max_size=4)
+        super().__init__(**kwargs)
         # Group elements for the FlipInput.
         # 0. The text
         # 1. The group holding the temporary scroll bitmap
@@ -235,8 +235,7 @@ class FlipInput(Widget, Control):
         self._update_position()  # call Widget superclass function to reposition
 
         self._animation_group = displayio.Group(
-            max_size=1,
-            scale=self._font_scale,
+            scale=self._font_scale
         )  # holds the animation bitmap
         # self._animation_group.x = -1 * left * (1)
         # self._animation_group.y = -1 * top * (1)

--- a/examples/displayio_flipinput_simpletest.py
+++ b/examples/displayio_flipinput_simpletest.py
@@ -92,7 +92,7 @@ my_flip2.value = my_flip2.value_list.index("21")  # find the index yourself by
 my_flip3.value = "2015"  # or set the value based on a string that is in the value_list
 
 # Create the group to display and append the FlipInput widgets
-my_group = displayio.Group(max_size=3)
+my_group = displayio.Group()
 my_group.append(my_flip1)
 my_group.append(my_flip2)
 my_group.append(my_flip3)


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

Tested on a Pynt:
```
Adafruit CircuitPython 6.3.0 on 2021-06-01; Adafruit PyPortal with samd51j20
```